### PR TITLE
Add events for 2026 week 16

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 16, bilibili_url: "1191097725197746195", events: [
+    { date: "2026-04-13 20:00+08:00", type: "game", title: "哀鸿", },
+    { date: "2026-04-14 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-15 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-16 20:00+08:00", type: "game", title: "城破十日", },
+    { date: "2026-04-17 20:00+08:00", type: "game", title: "楚汉传奇", },
+    { date: "2026-04-18 19:00+08:00", type: "chat", title: "大家什么品味", },
+    { date: "2026-04-19 19:00+08:00", type: "radio", title: "电台TIME", },
+  ] },
+
   { year: 2026, week: 15, bilibili_url: "1188505124019896352", events: [
     { date: "2026-04-06 20:00+08:00", type: "game", title: "哀鸿", },
     { date: "2026-04-07 20:00+08:00", type: "rest", title: "", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -53,12 +53,12 @@ export const events: WeekItem[] = [
   // ] },
 
   { year: 2026, week: 16, bilibili_url: "1191097725197746195", events: [
-    { date: "2026-04-13 20:00+08:00", type: "game", title: "哀鸿", },
-    { date: "2026-04-14 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-13 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-14 20:00+08:00", type: "game", title: "哀鸿", },
     { date: "2026-04-15 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-16 20:00+08:00", type: "game", title: "城破十日", },
     { date: "2026-04-17 20:00+08:00", type: "game", title: "楚汉传奇", },
-    { date: "2026-04-18 19:00+08:00", type: "chat", title: "大家什么品味", },
+    { date: "2026-04-18 19:00+08:00", type: "sub", title: "大家什么品味", },
     { date: "2026-04-19 19:00+08:00", type: "radio", title: "电台TIME", },
   ] },
 


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 16**.

### Events Added
- 2026-04-13 20:00+08:00: game - 哀鸿
- 2026-04-14 20:00+08:00: rest
- 2026-04-15 20:00+08:00: rest
- 2026-04-16 20:00+08:00: game - 城破十日
- 2026-04-17 20:00+08:00: game - 楚汉传奇
- 2026-04-18 19:00+08:00: chat - 大家什么品味
- 2026-04-19 19:00+08:00: radio - 电台TIME

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*