### PR TITLE
Add events for 2026 week 17

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -57,8 +57,8 @@ export const events: WeekItem[] = [
     { date: "2026-04-21 20:00+08:00", type: "game", title: "哀鸿", },
     { date: "2026-04-22 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-23 20:00+08:00", type: "game", title: "伊势人鱼物语", steam: 2701440 },
-    { date: "2026-04-24 20:00+08:00", type: "game", title: "楚汉传奇", },
-    { date: "2026-04-25 19:00+08:00", type: "game", title: "电王我TRYTRY", },
+    { date: "2026-04-24 20:00+08:00", type: "watch", title: "楚汉传奇", },
+    { date: "2026-04-25 19:00+08:00", type: "watch", title: "电王我TRYTRY", },
     { date: "2026-04-26 19:00+08:00", type: "game", title: "一起玩糖豆人", steam: 1097150 },
   ] },
 

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 17, events: [
+    { date: "2026-04-20 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-21 20:00+08:00", type: "game", title: "哀鸿", },
+    { date: "2026-04-22 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-23 20:00+08:00", type: "game", title: "伊势八人物语", },
+    { date: "2026-04-24 20:00+08:00", type: "game", title: "楚汉传奇", },
+    { date: "2026-04-25 19:00+08:00", type: "game", title: "电王我TRYTRY", },
+    { date: "2026-04-26 19:00+08:00", type: "game", title: "一起玩糖豆人", },
+  ] },
+
   { year: 2026, week: 16, bilibili_url: "1191097725197746195", events: [
     { date: "2026-04-13 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-14 20:00+08:00", type: "game", title: "哀鸿", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -56,10 +56,10 @@ export const events: WeekItem[] = [
     { date: "2026-04-20 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-21 20:00+08:00", type: "game", title: "哀鸿", },
     { date: "2026-04-22 20:00+08:00", type: "rest", title: "", },
-    { date: "2026-04-23 20:00+08:00", type: "game", title: "伊势人鱼物语", },
+    { date: "2026-04-23 20:00+08:00", type: "game", title: "伊势人鱼物语", steam: 2701440 },
     { date: "2026-04-24 20:00+08:00", type: "game", title: "楚汉传奇", },
     { date: "2026-04-25 19:00+08:00", type: "game", title: "电王我TRYTRY", },
-    { date: "2026-04-26 19:00+08:00", type: "game", title: "一起玩糖豆人", },
+    { date: "2026-04-26 19:00+08:00", type: "game", title: "一起玩糖豆人", steam: 1097150 },
   ] },
 
   { year: 2026, week: 16, bilibili_url: "1191097725197746195", events: [

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -56,7 +56,7 @@ export const events: WeekItem[] = [
     { date: "2026-04-20 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-21 20:00+08:00", type: "game", title: "哀鸿", },
     { date: "2026-04-22 20:00+08:00", type: "rest", title: "", },
-    { date: "2026-04-23 20:00+08:00", type: "game", title: "伊势八人物语", },
+    { date: "2026-04-23 20:00+08:00", type: "game", title: "伊势人鱼物语", },
     { date: "2026-04-24 20:00+08:00", type: "game", title: "楚汉传奇", },
     { date: "2026-04-25 19:00+08:00", type: "game", title: "电王我TRYTRY", },
     { date: "2026-04-26 19:00+08:00", type: "game", title: "一起玩糖豆人", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 17**.

### Events Added
- 2026-04-20 20:00+08:00: rest
- 2026-04-21 20:00+08:00: game - 哀鸿
- 2026-04-22 20:00+08:00: rest
- 2026-04-23 20:00+08:00: game - 伊势八人物语
- 2026-04-24 20:00+08:00: game - 楚汉传奇
- 2026-04-25 19:00+08:00: game - 电王我TRYTRY
- 2026-04-26 19:00+08:00: game - 一起玩糖豆人

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*