### PR TITLE
Add events for 2026 week 18

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 18, bilibili_url: "1196717195966545922", events: [
+    { date: "2026-04-27 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-28 20:00+08:00", type: "watch", title: "楚汉传奇", },
+    { date: "2026-04-29 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-04-30 20:00+08:00", type: "game", title: "天国拯救", },
+    { date: "2026-05-01 20:00+08:00", type: "game", title: "光遇", },
+    { date: "2026-05-02 19:00+08:00", type: "watch", title: "看恐怖片(直白)", },
+    { date: "2026-05-03 19:00+08:00", type: "game", title: "这是谐音梗", },
+  ] },
+
   { year: 2026, week: 17, events: [
     { date: "2026-04-20 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-21 20:00+08:00", type: "game", title: "哀鸿", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -56,10 +56,10 @@ export const events: WeekItem[] = [
     { date: "2026-04-27 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-28 20:00+08:00", type: "watch", title: "楚汉传奇", },
     { date: "2026-04-29 20:00+08:00", type: "rest", title: "", },
-    { date: "2026-04-30 20:00+08:00", type: "game", title: "天国拯救", },
+    { date: "2026-04-30 20:00+08:00", type: "game", title: "天国拯救", steam: 1771300 },
     { date: "2026-05-01 20:00+08:00", type: "game", title: "光遇", },
-    { date: "2026-05-02 19:00+08:00", type: "watch", title: "看恐怖片(直白)", },
-    { date: "2026-05-03 19:00+08:00", type: "game", title: "这是谐音梗", },
+    { date: "2026-05-02 19:00+08:00", type: "watch", title: "看恐怖片(直白", },
+    { date: "2026-05-03 19:00+08:00", type: "game", title: "这是谐音梗", steam: 4164310 },
   ] },
 
   { year: 2026, week: 17, events: [


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 18**.

### Events Added
- 2026-04-27 20:00+08:00: rest
- 2026-04-28 20:00+08:00: watch - 楚汉传奇
- 2026-04-29 20:00+08:00: rest
- 2026-04-30 20:00+08:00: game - 天国拯救
- 2026-05-01 20:00+08:00: game - 光遇
- 2026-05-02 19:00+08:00: watch - 看恐怖片(直白)
- 2026-05-03 19:00+08:00: game - 这是谐音梗

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*