### PR TITLE
Add events for 2026 week 19

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -53,8 +53,8 @@ export const events: WeekItem[] = [
   // ] },
 
   { year: 2026, week: 19, events: [
-    { date: "2026-05-04 20:00+08:00", type: "game", title: "伊势人鱼物语", },
-    { date: "2026-05-05 20:00+08:00", type: "chat", title: "来辣！", },
+    { date: "2026-05-04 20:00+08:00", type: "game", title: "伊势人鱼物语", steam：2701440},
+    { date: "2026-05-05 20:00+08:00", type: "chat", title: "休假杂谈回", },
     { date: "2026-05-06 20:00+08:00", type: "rest", title: "", },
     { date: "2026-05-07 20:00+08:00", type: "rest", title: "", },
     { date: "2026-05-08 20:00+08:00", type: "rest", title: "", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 19, events: [
+    { date: "2026-05-04 20:00+08:00", type: "game", title: "伊势人鱼物语", },
+    { date: "2026-05-05 20:00+08:00", type: "chat", title: "来辣！", },
+    { date: "2026-05-06 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-05-07 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-05-08 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-05-09 19:00+08:00", type: "watch", title: "假面骑士zzz", },
+    { date: "2026-05-10 19:00+08:00", type: "rest", title: "", },
+  ] },
+
   { year: 2026, week: 18, bilibili_url: "1196717195966545922", events: [
     { date: "2026-04-27 20:00+08:00", type: "rest", title: "", },
     { date: "2026-04-28 20:00+08:00", type: "watch", title: "楚汉传奇", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 19**.

### Events Added
- 2026-05-04 20:00+08:00: game - 伊势人鱼物语
- 2026-05-05 20:00+08:00: chat - 来辣！
- 2026-05-06 20:00+08:00: rest
- 2026-05-07 20:00+08:00: rest
- 2026-05-08 20:00+08:00: rest
- 2026-05-09 19:00+08:00: watch - 假面骑士zzz
- 2026-05-10 19:00+08:00: rest

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*