### PR TITLE
Add events for 2026 week 27

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 27, bilibili_url: "1219648279791271945", events: [
+    { date: "2026-06-29 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-06-30 20:00+08:00", type: "watch", title: "楚汉传奇", },
+    { date: "2026-07-01 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-02 20:00+08:00", type: "game", title: "活侠传", },
+    { date: "2026-07-03 14:00+08:00", type: "chat", title: "午间奶茶店", },
+    { date: "2026-07-04 19:00+08:00", type: "sub", title: "梦境之花", },
+    { date: "2026-07-05 19:00+08:00", type: "game", title: "GAME TIME", },
+  ] },
+
   { year: 2026, week: 26, events: [
     { date: "2026-06-22 20:00+08:00", type: "rest", title: "", },
     { date: "2026-06-23 20:00+08:00", type: "watch", title: "楚汉传奇", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 27**.

### Events Added
- 2026-06-29 20:00+08:00: rest
- 2026-06-30 20:00+08:00: watch - 楚汉传奇
- 2026-07-01 20:00+08:00: rest
- 2026-07-02 20:00+08:00: game - 活侠传
- 2026-07-03 14:00+08:00: chat - 午间奶茶店
- 2026-07-04 19:00+08:00: sub - 梦境之花
- 2026-07-05 19:00+08:00: game - GAME TIME

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new weekly event schedule for 2026 week 27, including dates from 2026-06-29 through 2026-07-05.
  * Included a new related video link for the updated schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->