### PR TITLE
Add events for 2026 week 28

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 28, events: [
+    { date: "2026-07-06 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-07 20:00+08:00", type: "watch", title: "楚汉传奇", },
+    { date: "2026-07-08 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-09 20:00+08:00", type: "game", title: "活侠传", },
+    { date: "2026-07-10 20:00+08:00", type: "watch", title: "假面骑士zzz", },
+    { date: "2026-07-11 15:00+08:00", type: "special", title: "BW互动", },
+    { date: "2026-07-12 19:00+08:00", type: "chat", title: "BW后日谈", },
+  ] },
+
   { year: 2026, week: 27, bilibili_url: "1219648279791271945", events: [
     { date: "2026-06-29 20:00+08:00", type: "rest", title: "", },
     { date: "2026-06-30 20:00+08:00", type: "watch", title: "楚汉传奇", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,7 +52,7 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
-  { year: 2026, week: 28, events: [
+  { year: 2026, week: 28, bilibili_url: "1222282086871728134", events: [
     { date: "2026-07-06 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-07 20:00+08:00", type: "watch", title: "楚汉传奇", },
     { date: "2026-07-08 20:00+08:00", type: "rest", title: "", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 28**.

### Events Added
- 2026-07-06 20:00+08:00: rest
- 2026-07-07 20:00+08:00: watch - 楚汉传奇
- 2026-07-08 20:00+08:00: rest
- 2026-07-09 20:00+08:00: game - 活侠传
- 2026-07-10 20:00+08:00: watch - 假面骑士zzz
- 2026-07-11 15:00+08:00: special - BW互动
- 2026-07-12 19:00+08:00: chat - BW后日谈

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional weekly event schedule for **2026 week 28**, covering **July 6–12**.
  * Included **seven** new event entries with their scheduled dates, event types, and titles (where available).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->