### PR TITLE
Add events for 2026 week 29

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,13 +52,13 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
-  { year: 2026, week: 29, events: [
+  { year: 2026, week: 29, bilibili_url: "1224886739691110401", events: [
     { date: "2026-07-13 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-14 20:00+08:00", type: "watch", title: "楚汉传奇", },
     { date: "2026-07-15 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-16 20:00+08:00", type: "game", title: "活侠传", },
     { date: "2026-07-17 20:00+08:00", type: "game", title: "GAME TIME", },
-    { date: "2026-07-18 19:00+08:00", type: "chat", title: "看会儿0.0", },
+    { date: "2026-07-18 19:00+08:00", type: "watch", title: "看会儿0.0", },
     { date: "2026-07-19 19:00+08:00", type: "radio", title: "读书电台", },
   ] },
 

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 29, events: [
+    { date: "2026-07-13 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-14 20:00+08:00", type: "watch", title: "楚汉传奇", },
+    { date: "2026-07-15 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-16 20:00+08:00", type: "game", title: "活侠传", },
+    { date: "2026-07-17 20:00+08:00", type: "game", title: "GAME TIME", },
+    { date: "2026-07-18 19:00+08:00", type: "chat", title: "看会儿0.0", },
+    { date: "2026-07-19 19:00+08:00", type: "radio", title: "读书电台", },
+  ] },
+
   { year: 2026, week: 28, bilibili_url: "1222282086871728134", events: [
     { date: "2026-07-06 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-07 20:00+08:00", type: "watch", title: "楚汉传奇", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 29**.

### Events Added
- 2026-07-13 20:00+08:00: rest
- 2026-07-14 20:00+08:00: watch - 楚汉传奇
- 2026-07-15 20:00+08:00: rest
- 2026-07-16 20:00+08:00: game - 活侠传
- 2026-07-17 20:00+08:00: game - GAME TIME
- 2026-07-18 19:00+08:00: chat - 看会儿0.0
- 2026-07-19 19:00+08:00: radio - 读书电台

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the event schedule for July 13–19, 2026 (seven planned activities).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->