### PR TITLE
Add events for 2026 week 30

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -58,7 +58,7 @@ export const events: WeekItem[] = [
     { date: "2026-07-22 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-23 20:00+08:00", type: "game", title: "养女儿", },
     { date: "2026-07-24 20:00+08:00", type: "game", title: "GAME TIME", },
-    { date: "2026-07-25 19:00+08:00", type: "collab", title: "黑泽君 ( ", },
+    { date: "2026-07-25 19:00+08:00", type: "watch", title: "黑泽君 ( ", },
     { date: "2026-07-26 19:00+08:00", type: "sing", title: "歌回来袭", },
   ] },
 

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 30, events: [
+    { date: "2026-07-20 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-21 20:00+08:00", type: "watch", title: "楚汉传奇", },
+    { date: "2026-07-22 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-23 20:00+08:00", type: "game", title: "养女儿", },
+    { date: "2026-07-24 20:00+08:00", type: "game", title: "GAME TIME", },
+    { date: "2026-07-25 19:00+08:00", type: "collab", title: "黑泽君 ( ", },
+    { date: "2026-07-26 19:00+08:00", type: "sing", title: "歌回来袭", },
+  ] },
+
   { year: 2026, week: 29, bilibili_url: "1224886739691110401", events: [
     { date: "2026-07-13 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-14 20:00+08:00", type: "watch", title: "楚汉传奇", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,7 +52,7 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
-  { year: 2026, week: 30, events: [
+  { year: 2026, week: 30, bilibili_url: "1227473362290212896", events: [
     { date: "2026-07-20 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-21 20:00+08:00", type: "watch", title: "楚汉传奇", },
     { date: "2026-07-22 20:00+08:00", type: "rest", title: "", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 30**.

### Events Added
- 2026-07-20 20:00+08:00: rest
- 2026-07-21 20:00+08:00: watch - 楚汉传奇
- 2026-07-22 20:00+08:00: rest
- 2026-07-23 20:00+08:00: game - 养女儿
- 2026-07-24 20:00+08:00: game - GAME TIME
- 2026-07-25 19:00+08:00: collab - 黑泽君 ( 
- 2026-07-26 19:00+08:00: sing - 歌回来袭

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added event listings for the week of **July 20–26, 2026**, including new collaboration and singing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->