### PR TITLE
Add events for 2026 week 31

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 31, events: [
+    { date: "2026-07-27 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-07-28 20:00+08:00", type: "sing", title: "歌回", },
+    { date: "2026-07-29 20:00+08:00", type: "game", title: "石头门", steam: 412830, },
+    { date: "2026-07-30 20:00+08:00", type: "chat", title: "绿宝我的绿宝", },
+    { date: "2026-07-31 20:00+08:00", type: "game", title: "GAMETIME", },
+    { date: "2026-08-01 19:00+08:00", type: "watch", title: "看会儿o.o", },
+    { date: "2026-08-02 19:00+08:00", type: "rest", title: "ZZZZZZZZZ", },
+  ] },
+
   { year: 2026, week: 30, bilibili_url: "1227473362290212896", events: [
     { date: "2026-07-20 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-21 20:00+08:00", type: "watch", title: "楚汉传奇", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,13 +52,13 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
-  { year: 2026, week: 31, events: [
+  { year: 2026, week: 31, bilibili_url: "1230084453272911893", events: [
     { date: "2026-07-27 20:00+08:00", type: "rest", title: "", },
     { date: "2026-07-28 20:00+08:00", type: "sing", title: "歌回", },
-    { date: "2026-07-29 20:00+08:00", type: "game", title: "石头门", steam: 412830, },
-    { date: "2026-07-30 20:00+08:00", type: "chat", title: "绿宝我的绿宝", },
+    { date: "2026-07-29 20:00+08:00", type: "watch", title: "石头门", steam: 412830, },
+    { date: "2026-07-30 20:00+08:00", type: "game", title: "绿宝我的绿宝", },
     { date: "2026-07-31 20:00+08:00", type: "game", title: "GAMETIME", },
-    { date: "2026-08-01 19:00+08:00", type: "watch", title: "看会儿o.o", },
+    { date: "2026-08-01 19:00+08:00", type: "watch", title: "看会儿0.0", },
     { date: "2026-08-02 19:00+08:00", type: "rest", title: "ZZZZZZZZZ", },
   ] },
 


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 31**.

### Events Added
- 2026-07-27 20:00+08:00: rest
- 2026-07-28 20:00+08:00: sing - 歌回
- 2026-07-29 20:00+08:00: game - 石头门
- 2026-07-30 20:00+08:00: chat - 绿宝我的绿宝
- 2026-07-31 20:00+08:00: game - GAMETIME
- 2026-08-01 19:00+08:00: watch - 看会儿o.o
- 2026-08-02 19:00+08:00: rest - ZZZZZZZZZ

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added the schedule for the week of July 27–August 2, 2026.
  * Included seven scheduled events with dates, types, titles, and related details, including one with Steam information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->