### PR TITLE
Add events for 2026 week 33

### DIFF
--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,7 +52,7 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
-  { year: 2026, week: 33, events: [
+  { year: 2026, week: 33, bilibili_url: "1235278911293620229", events: [
     { date: "2026-08-10 20:00+08:00", type: "rest", title: "", },
     { date: "2026-08-11 20:00+08:00", type: "game", title: "石头门", },
     { date: "2026-08-12 20:00+08:00", type: "rest", title: "", },

--- a/data/events.tsx
+++ b/data/events.tsx
@@ -52,6 +52,16 @@ export const events: WeekItem[] = [
   //   { date: "2023-00-00 19:00+08:00", type: "", title: "", rec: "", },
   // ] },
 
+  { year: 2026, week: 33, events: [
+    { date: "2026-08-10 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-08-11 20:00+08:00", type: "game", title: "石头门", },
+    { date: "2026-08-12 20:00+08:00", type: "rest", title: "", },
+    { date: "2026-08-13 20:00+08:00", type: "chat", title: "什么男同学", },
+    { date: "2026-08-14 20:00+08:00", type: "game", title: "GAME TIME", },
+    { date: "2026-08-15 19:00+08:00", type: "sub", title: "梦境之花续", },
+    { date: "2026-08-16 19:00+08:00", type: "radio", title: "读书电台", },
+  ] },
+
   { year: 2026, week: 32, bilibili_url: "1232682320110026772", events: [
     { date: "2026-08-03 20:00+08:00", type: "rest", title: "", },
     { date: "2026-08-04 20:00+08:00", type: "chat", title: "助手!老婆!", },


### PR DESCRIPTION
## Summary

This PR adds the schedule events for **2026 Week 33**.

### Events Added
- 2026-08-10 20:00+08:00: rest
- 2026-08-11 20:00+08:00: game - 石头门
- 2026-08-12 20:00+08:00: rest
- 2026-08-13 20:00+08:00: chat - 什么男同学
- 2026-08-14 20:00+08:00: game - GAME TIME
- 2026-08-15 19:00+08:00: sub - 梦境之花续
- 2026-08-16 19:00+08:00: radio - 读书电台

---
*Created via [LAPLACE Chronos](https://chronos.laplace.live)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the schedule for August 10–16, 2026, including rest days, games, chats, subscription events, and radio broadcasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->